### PR TITLE
fix: indexedDB와 firebase를 결합하여 임시글 로직 수정

### DIFF
--- a/src/pages/posts/[id]/index.tsx
+++ b/src/pages/posts/[id]/index.tsx
@@ -20,7 +20,7 @@ import MainMenu from "@/components/common/MainMenu";
 import { IUserInfo } from "@/types/users";
 import { IFirebasePost, IMeta } from "@/types/blog";
 import { formatTimestampToDateStr } from "@/utils/common";
-import { getPostById } from "@/utils/\bblog";
+import { getPostById, removePostByIdFromFirebase } from "@/utils/\bblog";
 import { GetStaticPaths, GetStaticProps } from "next";
 import { Params } from "next/dist/shared/lib/router/utils/route-matcher";
 
@@ -180,22 +180,26 @@ export default function Detail({
     }
   };
 
-  const onRemovePost = async () => {
+  const onRemovePost = async (id: string) => {
     // firebase 문서 삭제
-    // const id = data.id;
-    // await deleteDoc(doc(firestore, "posts", id));
+    const result = await removePostByIdFromFirebase(id);
+    if (result) {
+      alert("문서가 삭제되었습니다.");
+      router.push("/");
+    } else {
+      alert("문서의 삭제에 실패했습니다. 다시 시도해주세요.");
+    }
 
     // 로컬 문서 삭제
-    const response = await fetch(`/api/posts?id=${meta?.id}`, {
-      method: "DELETE",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
-    if (response.ok) {
-      router.push("/");
-    }
-    alert("문서가 삭제되었습니다.");
+    // const response = await fetch(`/api/posts?id=${meta?.id}`, {
+    //   method: "DELETE",
+    //   headers: {
+    //     "Content-Type": "application/json",
+    //   },
+    // });
+    // if (response.ok) {
+    //   router.push("/");
+    // }
   };
 
   const handleEdit = () => {
@@ -233,7 +237,7 @@ export default function Detail({
             {post?.meta?.userConfig?.uid === auth?.currentUser?.uid && (
               <BtnContainer>
                 <EditButton onClick={handleEdit} />
-                <DeleteButton onClick={onRemovePost} />
+                <DeleteButton onClick={() => onRemovePost(post.meta.id)} />
               </BtnContainer>
             )}
             <div>

--- a/src/pages/write/[id].tsx
+++ b/src/pages/write/[id].tsx
@@ -271,7 +271,7 @@ export default function Write({ post }: WriteType) {
         await setDoc(doc(firestore, "posts", `${id}`), {
           id,
           title,
-          created_at: Timestamp.fromDate(new Date()),
+          created_at: serverTimestamp(),
           description,
           content: encodedText,
           userConfig,
@@ -330,14 +330,28 @@ export default function Write({ post }: WriteType) {
 
   const handleSave = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    const config: IIndexedDB = {
-      id: id as string,
-      title,
-      content,
-      description,
-    };
-    saveDraftToIndexedDB(config);
-    router.push("/saves");
+    const user = auth.currentUser;
+    if (user && user.uid && user.displayName && user.email && user.photoURL) {
+      const userConfig = {
+        displayName: user.displayName,
+        email: user.email,
+        photoUrl: user.photoURL,
+        uid: user.uid,
+      };
+      const config: IIndexedDB = {
+        id: id as string,
+        title,
+        content,
+        description,
+        createdAt: serverTimestamp(),
+        userConfig,
+      };
+      saveDraftToIndexedDB(config);
+      router.push("/saves");
+    } else {
+      alert("로그인 상태로 시도해주세요.");
+      router.push("/login");
+    }
   };
 
   return (

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -1,4 +1,4 @@
-import { Timestamp } from "firebase/firestore";
+import { FieldValue, Timestamp } from "firebase/firestore";
 
 export interface IMeta {
   id: string;
@@ -9,8 +9,6 @@ export interface IMeta {
   userConfig: Owner;
 }
 
-export interface IPost extends IMeta {}
-
 interface Owner {
   displayName: string;
   email: string;
@@ -19,11 +17,12 @@ interface Owner {
 }
 
 export interface IIndexedDB {
-  [index: string]: any;
   id: string;
   title: string;
   content: string;
   description: string;
+  createdAt: Timestamp | FieldValue;
+  userConfig: Owner;
 }
 
 export interface IFirebasePost {
@@ -33,12 +32,7 @@ export interface IFirebasePost {
   content: string;
   created_at: Timestamp | string;
   update_at: Timestamp | string;
-  userConfig: {
-    displayName: string | null;
-    email: string;
-    photoUrl: string | null;
-    uid: string;
-  };
+  userConfig: Owner;
   meta: {
     like: number;
   };

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -2,109 +2,230 @@ import { IFirebasePost, IIndexedDB, IMeta } from "@/types/blog";
 import {
   Timestamp,
   collection,
+  deleteDoc,
   doc,
   getDoc,
   getDocs,
   orderBy,
   query,
+  serverTimestamp,
+  setDoc,
+  updateDoc,
 } from "firebase/firestore";
 import { auth, firestore } from "../../firebase";
+import { resolve } from "path";
+import { rejects } from "assert";
+
+// 임시글 관련 함수
 
 // indexedDB에 임시 저장
-export const setDraftToIndexedDB = (post: IIndexedDB[]) => {
-  if (!window) {
-    alert(
-      "Your browser doesn't support a stable version of IndexedDB. Such and such feature will not be available."
-    );
-  } else {
-    // window.indexedDB = window.indexedDB;
-    // window.IDBTransaction = window.IDBTransaction;
-    // window.IDBKeyRange = window.IDBKeyRange;
-    const req = window.indexedDB.open("MyObjectStore", 1);
-    req.onerror = function (e) {
-      console.log("error ", e);
-    };
-    req.onupgradeneeded = function (e) {
-      console.log("su", e);
-      // Save the IDBDatabase interface
-      const db = req.result;
-      // Create an objectStore for this database
-      const store = db.createObjectStore("Drafts", { keyPath: "id" });
-      store.createIndex("DraftIndex", "Draft");
-    };
-    req.onsuccess = function () {
-      const db = req.result;
-      const tx = db.transaction("Drafts", "readwrite");
-      const store = tx.objectStore("Drafts");
-
-      // add post data
-      store.put(post);
-      // store.put({ id: router.query.id, post: { title, content } });
-
-      //query the post data
-      const request = store.openCursor();
-
-      request.onsuccess = function (e: any) {
-        const cursor = e?.target?.result;
-
-        if (cursor) {
-          console.log(
-            `Key: ${cursor.key}, Value: ${JSON.stringify(cursor.value)}`
-          );
-
-          // Move to the next item in the store
-          cursor.continue();
-        } else {
-          console.log("All items have been displayed");
-        }
-
-        db.close();
+export const setDraftToIndexedDB = (post: IIndexedDB) => {
+  return new Promise((resolve, rejects) => {
+    if (!window) {
+      alert(
+        "Your browser doesn't support a stable version of IndexedDB. Such and such feature will not be available."
+      );
+    } else {
+      const req = window.indexedDB.open("MyObjectStore", 1);
+      req.onerror = function (e) {
+        console.log("indexedDB open error ", e);
       };
-    };
-  }
+      req.onupgradeneeded = function (e) {
+        const db = req.result;
+        const store = db.createObjectStore("Drafts", { keyPath: "id" });
+        store.createIndex("DraftIndex", "Draft");
+      };
+      req.onsuccess = function () {
+        const db = req.result;
+        const tx = db.transaction("Drafts", "readwrite");
+        const store = tx.objectStore("Drafts");
+
+        const putReq = store.put(post);
+
+        // const request = store.openCursor();
+
+        putReq.onsuccess = function () {
+          resolve(true);
+          db.close();
+        };
+
+        putReq.onerror = function () {
+          rejects(false);
+          db.close();
+        };
+      };
+    }
+  });
 };
 
 // indexedDB 에서 데이터 꺼내기
 export const getDraftFromIndexDB = () => {
-  if (window) {
-    const indexDBValueArr: IIndexedDB[] = [];
-    const open = indexedDB.open("MyObjectStore", 1);
-    open.onupgradeneeded = function () {
+  return new Promise((resolve, rejects) => {
+    if (window) {
+      const indexDBValueArr: IIndexedDB[] = [];
+      const open = indexedDB.open("MyObjectStore", 1);
+      open.onupgradeneeded = function () {
+        const db = open.result;
+        db.createObjectStore("Drafts", { keyPath: "id" });
+      };
+
+      open.onsuccess = function () {
+        const db = open.result;
+        const tx = db.transaction("Drafts", "readonly");
+        const store = tx.objectStore("Drafts");
+
+        const request = store.openCursor();
+
+        request.onsuccess = function (e: Event) {
+          const request = e?.target as IDBRequest;
+          const cursor = request.result as IDBCursorWithValue;
+          if (cursor) {
+            // const key = cursor.key as string;
+            const value = cursor.value;
+            const indexedDBObject: IIndexedDB = {
+              id: value.id,
+              title: value.title,
+              content: value.content,
+              description: value.description,
+              createdAt: value.createdAt,
+              userConfig: value.userConfig,
+            };
+
+            indexDBValueArr.push(indexedDBObject);
+            // if (cursor.key === router.query.id) {
+            //   setTitle(cursor.value.post.title);
+            //   setContent(cursor.value.post.text);
+            // }
+            cursor.continue();
+          } else {
+            resolve(indexDBValueArr);
+          }
+        };
+
+        request.onerror = function (e) {
+          console.log(e);
+          resolve(false);
+        };
+
+        tx.oncomplete = function () {
+          db.close();
+        };
+      };
+    }
+  });
+};
+
+//IndexedDB의 모든 임시글 삭제
+
+export const removeAllDraftsFromIndexedDB = () => {
+  return new Promise((resolve, rejects) => {
+    const open = window.indexedDB.open("MyObjectStore", 1);
+    open.onerror = function (e) {
+      console.log("error ", e);
+    };
+    open.onupgradeneeded = function (e) {
       const db = open.result;
       db.createObjectStore("Drafts", { keyPath: "id" });
     };
-
     open.onsuccess = function () {
       const db = open.result;
-      const tx = db.transaction("Drafts", "readonly");
+      const tx = db.transaction("Drafts", "readwrite");
       const store = tx.objectStore("Drafts");
 
-      const request = store.openCursor();
-      request.onsuccess = function (e: Event) {
-        const request = e?.target as IDBRequest;
-        const cursor = request.result as IDBCursorWithValue;
-        if (cursor) {
-          // const key = cursor.key as string;
-          const value = cursor.value;
-          const indexedDBObject: IIndexedDB = {
-            id: value.id,
-            title: value.title,
-            content: value.content,
-            description: value.description,
-            createdAt: value.createdAt,
-            userConfig: value.userConfig,
-          };
+      const clearRequest = store.clear();
+      clearRequest.onsuccess = function (e) {
+        db.close();
+        resolve(true);
+      };
 
-          indexDBValueArr.push(indexedDBObject);
-          // if (cursor.key === router.query.id) {
-          //   setTitle(cursor.value.post.title);
-          //   setContent(cursor.value.post.text);
-          // }
-          cursor.continue();
-        }
+      clearRequest.onerror = function () {
+        db.close();
+        rejects(false);
       };
     };
-    return indexDBValueArr;
+  });
+};
+
+// firebase store 에서 모든 임시글 불러오기
+export const getAllDraftsFromFirebase = async () => {
+  const draftsRef = collection(firestore, "drafts");
+  const q = query(draftsRef, orderBy("createdAt", "desc"));
+  const querySnapshot = await getDocs(q);
+  if (querySnapshot) {
+    const drafts: IFirebasePost[] = [];
+    querySnapshot.forEach((doc) => {
+      const title = doc.data().title;
+      const content = doc.data().content;
+      const decodedText = decodeURIComponent(title);
+      const decodedContent = decodeURIComponent(content);
+      doc.data().title = decodedText;
+      doc.data().content = decodedContent;
+      drafts.push(doc.data() as IFirebasePost);
+    });
+    return drafts;
+  } else {
+    return null;
+  }
+};
+
+// firebase store 저장소에 임시글 저장하기
+
+const setDraftToFirebase = async (id: string, obj) => {
+  const user = auth.currentUser;
+  if (user) {
+    try {
+      await setDoc(doc(firestore, "drafts", `${id}`), obj);
+      return true;
+    } catch (error) {
+      console.log(
+        "🚨 " + id + " 임시글 저장에 실패하셨습니다. 다시 시도해주세요.",
+        error
+      );
+      return false;
+    }
+  } else {
+    return false;
+  }
+};
+
+// firebase store 저장소에 임시글 업데이트하기
+
+const updateDraftToFirebase = async (id: string, obj) => {
+  try {
+    const docRef = doc(firestore, "drafts", `${id}`);
+    await updateDoc(docRef, {
+      ...obj,
+      update_at: serverTimestamp(),
+    });
+    return true;
+  } catch (error) {
+    console.log(
+      "🚨 " + id + " 임시글 업데이트에 실패하셨습니다. 다시 시도해주세요.",
+      error
+    );
+    return false;
+  }
+};
+
+// firebase store의 모든 임시글 삭제
+export const removeAllDraftsFromFirebase = async () => {
+  try {
+    const res = await deleteDoc(doc(firestore, "drafts"));
+    console.log(res);
+    return true;
+  } catch (error) {
+    console.log("🚨 모든 임시글 삭제에 실패: ", error);
+    return false;
+  }
+};
+// firebase store의 특정 임시글 삭제
+export const removeDraftByIdFromFirebase = async (id: string) => {
+  try {
+    await deleteDoc(doc(firestore, "drafts", id));
+    return true;
+  } catch (error) {
+    console.log("🚨 " + id + " 임시글 삭제에 실패: ", error);
+    return false;
   }
 };
 
@@ -132,28 +253,6 @@ export const getAllPostsFromFirebase = async () => {
   }
 };
 
-// firebase store 에서 모든 임시글 불러오기
-export const getAllDraftsFromFirebase = async () => {
-  const draftsRef = collection(firestore, "drafts");
-  const q = query(draftsRef, orderBy("createdAt", "desc"));
-  const querySnapshot = await getDocs(q);
-  if (querySnapshot) {
-    const drafts: IFirebasePost[] = [];
-    querySnapshot.forEach((doc) => {
-      const title = doc.data().title;
-      const content = doc.data().content;
-      const decodedText = decodeURIComponent(title);
-      const decodedContent = decodeURIComponent(content);
-      doc.data().title = decodedText;
-      doc.data().content = decodedContent;
-      drafts.push(doc.data() as IFirebasePost);
-    });
-    return drafts;
-  } else {
-    return null;
-  }
-};
-
 // Id를 이용해 게시글을 식별하여 가져오기
 export const getPostById = async (id: string) => {
   const docRef = doc(firestore, "posts", `${id}`);
@@ -175,36 +274,11 @@ export const getPostById = async (id: string) => {
   }
 };
 
-// const setPostToFirebase = async () => {
-//   const encodedText = encodeURIComponent(content);
-
-//   const user = auth.currentUser;
-//   if (user) {
-//     const userConfig = {
-//       displayName: user.displayName,
-//       email: user.email,
-//       photoUrl: user.photoURL,
-//       uid: user.uid,
-//     };
-//     try {
-//       await setDoc(doc(firestore, "posts", `${id}`), {
-//         id,
-//         title,
-//         created_at: Timestamp.fromDate(new Date()),
-//         description,
-//         content: encodedText,
-//         userConfig,
-//         meta: {
-//           like: 0,
-//         },
-//       });
-//       const docRef = doc(firestore, "posts", `${id}`);
-//       await updateDoc(docRef, {
-//         update_at: serverTimestamp(),
-//       });
-//       router.push("/");
-//     } catch (error) {
-//       console.log(error);
-//     }
-//   }
-// };
+export const removePostByIdFromFirebase = async (id: string) => {
+  try {
+    await deleteDoc(doc(firestore, "posts", id));
+    return true;
+  } catch (error) {
+    return false;
+  }
+};


### PR DESCRIPTION

indexedDB의 문제점을 해결하고자 firebase의 저장소와 결합하여 임시글 로직 구현
- 동일한 디바이스, 타 계정으로 로그인 시 현재 로그인된 사용자의 임시글을 포함하여 다른 사용자의 임시글까지 노출될 수 있음.
- 타 디바이스, 동일한 계정으로 로그인 시 위와 같은 문제점이 발생할 수 있음.

**해결 방법**
따라서, app이 빌드될 때, getStaticProps를 통해 한번 서버에서 데이터를 가져온 뒤, indexedDB에 저장하고, 읽고, 쓰는 등의 수정 행위는 indexedDB에서 사용하여 특정 케이스에서만 서버에 저장하도록 변경.